### PR TITLE
Add bounded archive, GIF recording & search CI

### DIFF
--- a/.github/workflows/search.yaml
+++ b/.github/workflows/search.yaml
@@ -1,0 +1,82 @@
+name: search
+
+on:
+  workflow_dispatch:
+    inputs:
+      duration:
+        description: 'Search duration in seconds'
+        required: true
+        default: '300'
+        type: string
+      max_active:
+        description: 'Max concurrent experiments'
+        required: false
+        default: '5'
+        type: string
+      max_archive:
+        description: 'Max archived experiments'
+        required: false
+        default: '50'
+        type: string
+      size_power_start:
+        description: 'Min grid size power (2^n)'
+        required: false
+        default: '6'
+        type: string
+      size_power_end:
+        description: 'Max grid size power (2^n)'
+        required: false
+        default: '8'
+        type: string
+      probability_step:
+        description: 'Mutation step for probabilities'
+        required: false
+        default: '0.05'
+        type: string
+
+jobs:
+  search:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: dtolnay/rust-toolchain@stable
+
+    - name: Build (release)
+      run: cargo build --release
+
+    - name: Write config
+      run: |
+        cat > data/config.ron << 'CONF'
+        (
+            max_active: ${{ inputs.max_active }},
+            max_in_flight: 20,
+            max_archive: ${{ inputs.max_archive }},
+            size_power: (start:${{ inputs.size_power_start }}, end:${{ inputs.size_power_end }}),
+            probability_step: ${{ inputs.probability_step }},
+            max_probability_weight: 8,
+        )
+        CONF
+        echo "Config:"
+        cat data/config.ron
+
+    - name: Run search
+      run: |
+        cargo run --release -- headless data/default-snap.ron ${{ inputs.duration }} \
+          > data/active/summary.md
+        cat data/active/summary.md >> "$GITHUB_STEP_SUMMARY"
+        echo "---"
+        cat data/active/summary.md
+
+    - name: Upload results
+      uses: actions/upload-artifact@v4
+      with:
+        name: search-results
+        path: |
+          data/active/summary.md
+          data/active/find.log
+          data/active/gifs/
+          data/active/e*-*.ron
+        retention-days: 90

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,57 @@
+# Seeker - Research Notes
+
+## What This Project Is
+
+Seeker is an experimental research project exploring how life emerges from simple rules (QLUE - Question of Life, Universe, and Everything). It's a cellular automata-based system that searches for interesting, survivable patterns through evolutionary mutation and selection.
+
+Two modes:
+- **Play** — manually advance a cellular automaton step-by-step in a TUI
+- **Find** — automatically search for interesting rule configurations via evolutionary algorithms
+
+## Architecture
+
+- `src/grid.rs` — 2D wrapped-coordinate grid with `Option<Cell>` storage
+- `src/sim.rs` — Simulation engine: probabilistic CA rules, grid advancement, statistics
+- `src/lab.rs` — Evolutionary search: parallel experiments, fitness-proportional selection, mutation
+- `src/main.rs` — TUI application (ratatui + crossterm), play/find modes
+
+## How the Search Works
+
+1. **Rules**: Probabilistic CA with a weighted kernel (neighborhood), spawn table, and keep table
+2. **Parallel experiments**: Up to `max_active` concurrent simulations via Choir work-stealing executor
+3. **Fitness-proportional selection**: Parents chosen weighted by fitness score
+4. **Mutations**: One of {spawn probs, keep probs, kernel weights, grid size} mutated per offspring
+5. **Fitness**: `log2(steps)` for extinct/saturate, `100 - 60*alive_avg` for survivors
+
+## High-Level Analysis & Suggestions
+
+### 1. Fitness Function Is Coarse
+Any simulation surviving to completion (even a boring static blob) gets fitness ~46-100, dominating experiments that went extinct at step 2048 (fit ~11). The search selects for "didn't die" not "interesting."
+**Suggestion**: Incorporate `alive_ratio_variance` into fitness — high variance = oscillation/dynamism.
+
+### 2. Only One Mutation Per Generation
+`mutate_snap` applies exactly one mutation type (25% chance each). Co-adapting spawn+keep tables requires many generations.
+**Suggestion**: Multiple mutations per offspring (Poisson-distributed), or correlated mutations.
+
+### 3. No Population Diversity Mechanism
+Fitness-proportional selection has no diversity pressure. One high-fitness experiment can dominate, causing premature convergence.
+**Suggestion**: Tournament selection, novelty bonus, or occasional random injection.
+
+### 4. Experiment Pool Grows Unbounded
+All concluded experiments remain in the pool forever. Early lucky survivors permanently skew selection.
+**Suggestion**: Sliding window or capped archive of N best. Decay fitness over time.
+
+### 5. Worker Thread Count Is Hardcoded
+Only 2 Choir workers but `max_active` defaults to 5 experiments.
+**Suggestion**: Scale workers to match cores or `max_active`.
+
+### 6. Kernel Mutation Is String-Level Surgery
+Kernel weights mutated via ASCII byte manipulation with `unsafe`. Fragile, limits weights to 0-9.
+**Suggestion**: Store kernel as numeric 2D structure, mutate numerically.
+
+### 7. Cell Velocity Tracked But Unused for Fitness
+`avg_velocity` computed per cell but never aggregated for fitness. Could be a secondary interestingness signal.
+
+### 8. No Structural Kernel Mutation
+Only weight values mutate, not kernel shape. Search is locked into initial topology.
+**Suggestion**: Add mutations that add/remove kernel positions to explore different neighborhoods.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,6 +143,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "compact_str"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -339,6 +345,16 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi 0.10.2+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "gif"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae047235e33e2829703574b54fdec96bfbad892062d97fed2f76022287de61b"
+dependencies = [
+ "color_quant",
+ "weezl",
 ]
 
 [[package]]
@@ -819,6 +835,7 @@ dependencies = [
  "criterion",
  "crossbeam-channel",
  "crossterm",
+ "gif",
  "log",
  "rand",
  "ratatui",
@@ -1097,6 +1114,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ ron = "0.8"
 rustc-hash = "1"
 serde = { version = "1", features = ["serde_derive"]}
 ratatui = { version = "0.29", features = ["crossterm"] }
+gif = "0.13"
 
 [dev-dependencies]
 criterion = "0.5"

--- a/data/config.ron
+++ b/data/config.ron
@@ -1,6 +1,7 @@
 (
     max_active: 5,
     max_in_flight: 20,
+    max_archive: 50,
     size_power: (start:6, end:8),
     probability_step: 0.05,
     max_probability_weight: 8,

--- a/src/lab.rs
+++ b/src/lab.rs
@@ -9,6 +9,7 @@ const CHANNEL_BOUND: usize = 200;
 pub struct Configuration {
     max_active: usize,
     max_in_flight: usize,
+    max_archive: usize,
     size_power: Range<usize>,
     probability_step: Probability,
     max_probability_weight: Weight,
@@ -181,6 +182,38 @@ impl Laboratory {
                 };
                 experiment.conclusion = Some(conclusion);
             }
+        }
+
+        // Prune concluded experiments to keep only the best `max_archive`.
+        // Active (in-flight) experiments are always retained.
+        let concluded_count = self
+            .experiments
+            .iter()
+            .filter(|ex| ex.conclusion.is_some())
+            .count();
+        if concluded_count > self.config.max_archive {
+            // Find the fitness threshold: sort concluded fitnesses descending,
+            // keep the top max_archive.
+            let mut concluded_fits: Vec<usize> = self
+                .experiments
+                .iter()
+                .filter(|ex| ex.conclusion.is_some())
+                .map(|ex| ex.fit)
+                .collect();
+            concluded_fits.sort_unstable_by(|a, b| b.cmp(a));
+            let min_fit = concluded_fits[self.config.max_archive - 1];
+            let mut kept = 0;
+            self.experiments.retain(|ex| {
+                if ex.conclusion.is_none() {
+                    return true; // always keep active
+                }
+                if ex.fit >= min_fit && kept < self.config.max_archive {
+                    kept += 1;
+                    true
+                } else {
+                    false
+                }
+            });
         }
 
         let mut total_fit = 0;

--- a/src/lab.rs
+++ b/src/lab.rs
@@ -23,6 +23,12 @@ pub struct Experiment {
     pub fit: usize,
 }
 
+impl Experiment {
+    pub fn snap(&self) -> &Snap {
+        &self.snap
+    }
+}
+
 struct TaskStatus {
     experiment_id: usize,
     step: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod grid;
 pub mod lab;
+pub mod render;
 pub mod sim;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use seeker::{grid, lab, sim};
+use seeker::{grid, lab, render, sim};
 
 const OCCUPANCY_HISTORY: usize = 50;
 
@@ -291,32 +291,37 @@ impl Drop for Output {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    use std::{fs::File, path::PathBuf};
+    use std::{fs, fs::File, path::PathBuf};
 
     const MY_NAME: &str = "seeker";
     const PLAY_COMMAND: &str = "play";
     const FIND_COMMAND: &str = "find";
     const HEADLESS_COMMAND: &str = "headless";
+    const REPLAY_COMMAND: &str = "replay";
 
-    let mut args = std::env::args();
-    let _exec_name = args.next().unwrap();
-    let command = match args.next() {
-        Some(cmd) => cmd,
-        None => {
-            println!("Usage:");
-            println!("{} {} [<path_to_snap>]", MY_NAME, PLAY_COMMAND);
-            println!("{} {} <path_to_init_snap>", MY_NAME, FIND_COMMAND);
-            println!("{} {} <path_to_init_snap>", MY_NAME, HEADLESS_COMMAND);
-            return Ok(());
-        }
+    let args: Vec<String> = std::env::args().collect();
+    let command = if args.len() < 2 {
+        println!("Usage:");
+        println!("{} {} [<path_to_snap>]", MY_NAME, PLAY_COMMAND);
+        println!("{} {} [<path_to_init_snap>]", MY_NAME, FIND_COMMAND);
+        println!(
+            "{} {} [<path_to_init_snap>] [<duration_secs>]",
+            MY_NAME, HEADLESS_COMMAND
+        );
+        println!("{} {} <path_to_snap> <output.gif>", MY_NAME, REPLAY_COMMAND);
+        return Ok(());
+    } else {
+        args[1].clone()
     };
-    let snap_name = match args.next() {
-        Some(string) => string,
-        None => "data/default-snap.ron".to_string(),
-    };
+
+    let snap_name = args
+        .get(2)
+        .cloned()
+        .unwrap_or_else(|| "data/default-snap.ron".to_string());
     let mut snap_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    snap_path.push(snap_name);
-    let init_snap = ron::de::from_reader(File::open(snap_path).unwrap()).unwrap();
+    snap_path.push(&snap_name);
+    let init_snap: sim::Snap =
+        ron::de::from_reader(File::open(&snap_path).unwrap()).unwrap();
 
     let mode = match command.as_str() {
         PLAY_COMMAND => Mode::Play {
@@ -333,28 +338,134 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             Mode::Find(lab)
         }
         HEADLESS_COMMAND => {
+            let duration_secs: u64 = args
+                .get(3)
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(120);
             let mut config_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
             config_path.push("data");
             config_path.push("config.ron");
             let config = ron::de::from_reader(File::open(config_path).unwrap()).unwrap();
             let mut lab = lab::Laboratory::new(config, "data/active/");
             lab.add_experiment(init_snap, 0);
-            println!("Running headless search...");
-            loop {
+            eprintln!("Running headless search for {}s...", duration_secs);
+            let start = std::time::Instant::now();
+            let deadline = std::time::Duration::from_secs(duration_secs);
+            while start.elapsed() < deadline {
                 lab.update();
                 std::thread::sleep(std::time::Duration::from_millis(50));
                 let experiments = lab.experiments();
                 let concluded = experiments.iter().filter(|e| e.conclusion.is_some()).count();
                 let active = experiments.len() - concluded;
                 let max_fit = experiments.iter().map(|e| e.fit).max().unwrap_or(0);
-                let total = experiments.len();
-                print!(
+                eprint!(
                     "\r[{} total, {} active, {} concluded] best fit: {}    ",
-                    total, active, concluded, max_fit
+                    experiments.len(),
+                    active,
+                    concluded,
+                    max_fit
                 );
-                use std::io::Write as _;
-                std::io::stdout().flush().ok();
             }
+            eprintln!();
+
+            // Collect interesting concluded experiments (survivors only)
+            let mut survivors: Vec<_> = lab
+                .experiments()
+                .iter()
+                .filter(|e| {
+                    matches!(
+                        e.conclusion,
+                        Some(sim::Conclusion::Done(..))
+                    )
+                })
+                .collect();
+            survivors.sort_by(|a, b| b.fit.cmp(&a.fit));
+
+            // Print structured summary
+            let total = lab.experiments().len();
+            let extinct_count = lab
+                .experiments()
+                .iter()
+                .filter(|e| matches!(e.conclusion, Some(sim::Conclusion::Extinct)))
+                .count();
+            let saturate_count = lab
+                .experiments()
+                .iter()
+                .filter(|e| matches!(e.conclusion, Some(sim::Conclusion::Saturate)))
+                .count();
+
+            println!("## Search Results");
+            println!();
+            println!("- Duration: {}s", duration_secs);
+            println!("- Total experiments: {}", total);
+            println!("- Survivors: {}", survivors.len());
+            println!("- Extinct: {}", extinct_count);
+            println!("- Saturated: {}", saturate_count);
+            println!();
+
+            if !survivors.is_empty() {
+                println!("### Top Survivors");
+                println!();
+                println!("| ID | Fitness | Alive Avg | Alive Var | Snap |");
+                println!("|----|---------|-----------|-----------|------|");
+                let top_n = survivors.len().min(10);
+                for exp in &survivors[..top_n] {
+                    if let Some(sim::Conclusion::Done(stats, _)) = &exp.conclusion {
+                        let snap_file = format!("e{}-{}.ron", exp.id, exp.steps);
+                        println!(
+                            "| {} | {} | {:.4} | {:.6} | {} |",
+                            exp.id, exp.fit, stats.alive_ratio_average,
+                            stats.alive_ratio_variance, snap_file
+                        );
+                    }
+                }
+                println!();
+
+                // Record GIFs for interesting survivors
+                let gif_count = top_n.min(5);
+                let gif_dir = PathBuf::from("data/active/gifs");
+                fs::create_dir_all(&gif_dir).unwrap();
+                println!("### Recorded GIFs");
+                println!();
+                for exp in &survivors[..gif_count] {
+                    let gif_path = gif_dir.join(format!("e{}.gif", exp.id));
+                    eprint!("Recording GIF for E[{}]...", exp.id);
+                    let mut sim = sim::Simulation::new(exp.snap()).unwrap();
+                    match render::record_gif(&mut sim, &gif_path, 4, 200) {
+                        Ok(frames) => {
+                            eprintln!(" {} frames", frames);
+                            println!("- `gifs/e{}.gif` ({} frames)", exp.id, frames);
+                        }
+                        Err(e) => {
+                            eprintln!(" error: {}", e);
+                        }
+                    }
+                }
+            }
+
+            return Ok(());
+        }
+        REPLAY_COMMAND => {
+            let output_path = args
+                .get(3)
+                .map(|s| PathBuf::from(s))
+                .unwrap_or_else(|| PathBuf::from("replay.gif"));
+            let mut sim = sim::Simulation::new(&init_snap).unwrap();
+            eprintln!(
+                "Replaying {} -> {}",
+                snap_path.display(),
+                output_path.display()
+            );
+            match render::record_gif(&mut sim, &output_path, 4, 200) {
+                Ok(frames) => {
+                    eprintln!("Wrote {} frames to {}", frames, output_path.display());
+                }
+                Err(e) => {
+                    eprintln!("Error: {}", e);
+                    std::process::exit(1);
+                }
+            }
+            return Ok(());
         }
         _ => {
             println!("Unknown command: '{}'", command);

--- a/src/main.rs
+++ b/src/main.rs
@@ -296,6 +296,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     const MY_NAME: &str = "seeker";
     const PLAY_COMMAND: &str = "play";
     const FIND_COMMAND: &str = "find";
+    const HEADLESS_COMMAND: &str = "headless";
 
     let mut args = std::env::args();
     let _exec_name = args.next().unwrap();
@@ -305,6 +306,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             println!("Usage:");
             println!("{} {} [<path_to_snap>]", MY_NAME, PLAY_COMMAND);
             println!("{} {} <path_to_init_snap>", MY_NAME, FIND_COMMAND);
+            println!("{} {} <path_to_init_snap>", MY_NAME, HEADLESS_COMMAND);
             return Ok(());
         }
     };
@@ -329,6 +331,30 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let mut lab = lab::Laboratory::new(config, "data/active/");
             lab.add_experiment(init_snap, 0);
             Mode::Find(lab)
+        }
+        HEADLESS_COMMAND => {
+            let mut config_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+            config_path.push("data");
+            config_path.push("config.ron");
+            let config = ron::de::from_reader(File::open(config_path).unwrap()).unwrap();
+            let mut lab = lab::Laboratory::new(config, "data/active/");
+            lab.add_experiment(init_snap, 0);
+            println!("Running headless search...");
+            loop {
+                lab.update();
+                std::thread::sleep(std::time::Duration::from_millis(50));
+                let experiments = lab.experiments();
+                let concluded = experiments.iter().filter(|e| e.conclusion.is_some()).count();
+                let active = experiments.len() - concluded;
+                let max_fit = experiments.iter().map(|e| e.fit).max().unwrap_or(0);
+                let total = experiments.len();
+                print!(
+                    "\r[{} total, {} active, {} concluded] best fit: {}    ",
+                    total, active, concluded, max_fit
+                );
+                use std::io::Write as _;
+                std::io::stdout().flush().ok();
+            }
         }
         _ => {
             println!("Unknown command: '{}'", command);

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,0 +1,97 @@
+use crate::grid::Grid;
+use crate::sim::Simulation;
+use std::fs::File;
+use std::path::Path;
+
+const CELL_SIZE: u16 = 2;
+
+fn velocity_color(cell: &crate::grid::Cell) -> u8 {
+    let v = cell.avg_velocity[0] * cell.avg_velocity[0]
+        + cell.avg_velocity[1] * cell.avg_velocity[1];
+    if v <= 0.03 {
+        1 // red
+    } else if v <= 0.10 {
+        2 // green
+    } else {
+        3 // blue
+    }
+}
+
+fn render_grid(grid: &Grid) -> Vec<u8> {
+    let size = grid.size();
+    let w = size.x as u16 * CELL_SIZE;
+    let h = size.y as u16 * CELL_SIZE;
+    let mut pixels = vec![0u8; w as usize * h as usize];
+    for y in 0..size.y {
+        for x in 0..size.x {
+            let color = match grid.get(x, y) {
+                Some(cell) => velocity_color(cell),
+                None => 0, // black
+            };
+            for dy in 0..CELL_SIZE {
+                for dx in 0..CELL_SIZE {
+                    let px = x as u16 * CELL_SIZE + dx;
+                    let py = y as u16 * CELL_SIZE + dy;
+                    pixels[py as usize * w as usize + px as usize] = color;
+                }
+            }
+        }
+    }
+    pixels
+}
+
+/// Record an animated GIF of a simulation run.
+/// Captures a frame every `frame_interval` steps, up to `max_frames` frames.
+pub fn record_gif(
+    sim: &mut Simulation,
+    output_path: &Path,
+    frame_interval: usize,
+    max_frames: usize,
+) -> Result<usize, Box<dyn std::error::Error>> {
+    let size = sim.grid().size();
+    let w = size.x as u16 * CELL_SIZE;
+    let h = size.y as u16 * CELL_SIZE;
+
+    let file = File::create(output_path)?;
+    let mut encoder = gif::Encoder::new(file, w, h, &[
+        0, 0, 0,       // 0: black (empty)
+        200, 50, 50,   // 1: red (low velocity)
+        50, 200, 50,   // 2: green (medium velocity)
+        50, 50, 200,   // 3: blue (high velocity)
+    ])?;
+    encoder.set_repeat(gif::Repeat::Infinite)?;
+
+    // First frame from initial state
+    let pixels = render_grid(sim.grid());
+    let mut frame = gif::Frame::default();
+    frame.width = w;
+    frame.height = h;
+    frame.delay = 8; // 80ms per frame
+    frame.buffer = std::borrow::Cow::Borrowed(&pixels);
+    encoder.write_frame(&frame)?;
+
+    let mut frames_written = 1;
+
+    loop {
+        if frames_written >= max_frames {
+            break;
+        }
+        match sim.advance() {
+            Ok(_) => {
+                if sim.last_step() % frame_interval == 0 {
+                    let pixels = render_grid(sim.grid());
+                    let mut frame = gif::Frame::default();
+                    frame.width = w;
+                    frame.height = h;
+                    frame.delay = 8;
+                    frame.buffer = std::borrow::Cow::Borrowed(&pixels);
+                    encoder.write_frame(&frame)?;
+                    frames_written += 1;
+                }
+            }
+            Err(_) => break,
+        }
+    }
+
+    Ok(frames_written)
+}


### PR DESCRIPTION
Summary:
	∙	Cap experiment archive (max_archive: 50) so old low-fitness experiments don’t permanently skew parent selection
	∙	Add headless mode (seeker headless <snap> <duration>) for running search without a terminal, with markdown summary output and automatic GIF recording of top survivors
	∙	Add replay command (seeker replay <snap.ron> <output.gif>) for deterministic GIF replay of any saved snapshot
	∙	Add manual search CI workflow (workflow_dispatch) with configurable parameters (duration, grid size, mutation step, etc.), posts results to job summary, uploads artifacts (logs, GIFs, snapshots)
Test plan
	∙	cargo check --workspace --no-default-features passes
	∙	cargo test --workspace --all-features passes
	∙	Headless mode runs, produces structured markdown summary and GIF files
	∙	Replay command produces deterministic GIF from saved snapshots
	∙	Trigger search workflow manually on GitHub to verify end-to-end